### PR TITLE
Stop using very generic name for a url variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Available variables are listed below, along with default values:
 ```yaml
 prometheus_rabbitmq_exporter_version: 0.20.0
 prometheus_rabbitmq_exporter_release_name: "rabbitmq_exporter-{{ prometheus_rabbitmq_exporter_version }}.linux-amd64"
-url: "https://github.com/kbudde/rabbitmq_exporter/releases/download/v{{ prometheus_rabbitmq_exporter_version }}/{{ prometheus_rabbitmq_exporter_release_name }}.tar.gz"
+prometheus_rabbitmq_exporter_url: "https://github.com/kbudde/rabbitmq_exporter/releases/download/v{{ prometheus_rabbitmq_exporter_version }}/{{ prometheus_rabbitmq_exporter_release_name }}.tar.gz"
 
 prometheus_rabbitmq_exporter_config_flags:
   'rabbit_url': 'http://localhost:15672'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 prometheus_rabbitmq_exporter_version: 0.20.0
 prometheus_rabbitmq_exporter_release_name: "rabbitmq_exporter-{{ prometheus_rabbitmq_exporter_version }}.linux-amd64"
-url: "https://github.com/kbudde/rabbitmq_exporter/releases/download/v{{ prometheus_rabbitmq_exporter_version }}/{{ prometheus_rabbitmq_exporter_release_name }}.tar.gz"
+prometheus_rabbitmq_exporter_url: "https://github.com/kbudde/rabbitmq_exporter/releases/download/v{{ prometheus_rabbitmq_exporter_version }}/{{ prometheus_rabbitmq_exporter_release_name }}.tar.gz"
 
 prometheus_rabbitmq_exporter_config_flags:
   'rabbit_url': 'http://localhost:15672'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: download prometheus rabbitmq exporter binary
   get_url:
-    url: "{{ url }}"
+    url: "{{ prometheus_rabbitmq_exporter_url }}"
     dest: "{{ prometheus_exporters_common_dist_dir }}/{{ prometheus_rabbitmq_exporter_release_name }}.tar.gz"
 
 - name: unarchive binary tarball


### PR DESCRIPTION
Using `url` as a variable name might cause problems with other roles. I think it would be better to prefix it as it's done for other variables.