### PR TITLE
Fix AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems' 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
     recurse: yes
     owner: "{{ prometheus_exporters_common_user}}"
     group: "{{ prometheus_exporters_common_group }}"
-  when: prometheus_rabbitmq_exporter_updated | changed
+  when: prometheus_rabbitmq_exporter_updated is changed
 
 - name: create symlink to the current release
   file:

--- a/templates/etc/systemd/system/prometheus-rabbitmq-exporter.service.j2
+++ b/templates/etc/systemd/system/prometheus-rabbitmq-exporter.service.j2
@@ -9,7 +9,7 @@ Group={{ prometheus_exporters_common_group }}
 ExecStart={{ prometheus_exporters_common_root_dir }}/rabbitmq_exporter_current/rabbitmq_exporter
 SyslogIdentifier=prometheus_rabbitmq_exporter
 Restart=always
-{% for flag, value in prometheus_rabbitmq_exporter_config_flags.iteritems() %}
+{% for flag, value in prometheus_rabbitmq_exporter_config_flags.items() %}
 Environment={%filter upper %}{{flag}}{% endfilter %}={{value}}
 {% endfor %}
 


### PR DESCRIPTION
#### 1. Usage of a Python 2 method instead of a Jinja2:
```
TASK [nwalke.prometheus-rabbitmq-exporter : create systemd service unit] ******************************************************
fatal: [rabbitmq-queues-prod-20]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'"}
```

> In Python2, dictionaries have iterkeys(), itervalues(), and iteritems() methods. These methods have been removed in Python3. Playbooks and Jinja2 templates should use dict.keys(), dict.values(), and dict.items() in order to be compatible with both Python2 and Python3.
[source](https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html)

#### 2. Ansible 2.7 deprecation warning

```
TASK [nwalke.prometheus-rabbitmq-exporter : update group and owner for files] *************************************************
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|changed` use `result is changed`. This 
feature will be removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
```

> As of Ansible 2.5, using a jinja test as a filter will generate a warning. The syntax for using a jinja test is as follows:
`variable is test_name`
[source](https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#test-syntax)


